### PR TITLE
Switch from type coercion (General Question)

### DIFF
--- a/exercises/exercise07/index.js
+++ b/exercises/exercise07/index.js
@@ -144,9 +144,9 @@ let Users = () => {
 }
 
 let UserProfile = (props) => {
-  let id = props.routeParams.userId
+  let id = parseInt(props.routeParams.userId)
   let user = USERS.filter((user) => {
-    return user.id == id;
+    return user.id === id;
   })[0];
 
   return (


### PR DESCRIPTION
Not that this is an issue in this context, but what are your opinions on using type coercion for comparing numbers from router params?

For instance if `props.routeParams.userId` was ever `true` for some reason, this would not render since the `user` object wouldn't exist.

Is there a standard way to handle variables from `routerParams`?

